### PR TITLE
Version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 URL Title Match
 ==================
 
-ExpressionEngine 2.+ accessory that forces the URL Title to match the Structure Page/Listing URL if the first character for the Structure URL is a digit or letter.
+ExpressionEngine 2.+ accessory that forces the URL Title and the Structure Page/Listing URL to match. When either input is updated and its first character is a digit or letter, the other will be updated to match.
 
 
 Installation


### PR DESCRIPTION
Your ExpressionEngine addon "url_title_match" is just what I needed. Unfortunately, it did not work in my newer install of EE. It turns out that EE's publish form no-longer includes an id parameter on the input elements, which your script relies on. This was a simple fix.

Additionally, it struck me that this accessory should really apply url title matching regardless of which input is updated. So I updated the script to trigger the matching from either the URL Title, or the Structure URL input.

This accessory was helpful for me, so I'm making my updates available in case they may be helpful for others.
